### PR TITLE
Feature: Früheste/Späteste Zeit für Timer vom Typ Sonnenaufgang / -untergang

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -39,6 +39,10 @@ struct s_cfg_timer {
   bool saturday;
   bool sunday;
   uint16_t grp_mask; // Group mask for included channels
+  bool use_min_time;
+  char min_time_value[6];   // fixed Time value (hh:mm)
+  bool use_max_time;
+  char max_time_value[6];   // fixed Time value (hh:mm)
 };
 
 struct s_cfg_geo {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -7,7 +7,11 @@
 
 /* D E C L A R A T I O N S ****************************************************/
 
-const int CFG_VERSION = 1;
+/**
+ * V1: Initial version of dewenni.
+ * V2: Added min/max times for timers.
+ */
+const int CFG_VERSION = 2;
 
 char filename[24] = {"/config.json"};
 bool setupMode;
@@ -242,6 +246,14 @@ void configInitValue() {
   config.gpio.mosi = 23;
   config.gpio.cs = 5;
   config.gpio.led_setup = LED_BUILTIN;
+
+  // timer
+  for (int i = 0; i < 6; i++) {
+    config.timer[i].use_min_time = false;
+    config.timer[i].use_max_time = false;
+    strncpy(config.timer[i].min_time_value, "", sizeof(config.timer[i].min_time_value));
+    strncpy(config.timer[i].max_time_value, "", sizeof(config.timer[i].max_time_value));
+  }
 }
 
 /**
@@ -397,6 +409,10 @@ void configSaveToFile() {
     timer["saturday"] = config.timer[i].saturday;
     timer["sunday"] = config.timer[i].sunday;
     timer["grp_mask"] = config.timer[i].grp_mask;
+    timer["use_min_time"] = config.timer[i].use_min_time;
+    timer["use_max_time"] = config.timer[i].use_max_time;
+    timer["min_time_value"] = config.timer[i].min_time_value;
+    timer["max_time_value"] = config.timer[i].max_time_value;
   }
 
   // Delete existing file, otherwise the configuration is appended to the file
@@ -586,6 +602,10 @@ void configLoadFromFile() {
       config.timer[i].saturday = timer["saturday"];
       config.timer[i].sunday = timer["sunday"];
       config.timer[i].grp_mask = timer["grp_mask"];
+      config.timer[i].use_min_time = timer["use_min_time"];
+      config.timer[i].use_max_time = timer["use_max_time"];
+      EspStrUtil::readJSONstring(config.timer[i].min_time_value, sizeof(config.timer[i].min_time_value), timer["min_time_value"]);
+      EspStrUtil::readJSONstring(config.timer[i].max_time_value, sizeof(config.timer[i].max_time_value), timer["max_time_value"]);
     }
   }
 

--- a/src/webUIcallback.cpp
+++ b/src/webUIcallback.cpp
@@ -346,6 +346,11 @@ void webCallback(const char *elementId, const char *value) {
     char saturdayId[32];
     char sundayId[32];
 
+    char useMinTime[32];
+    char minTimeValueId[32];
+    char useMaxTime[32];
+    char maxTimeValueId[32];
+
     snprintf(enableId, sizeof(enableId), "cfg_timer_%d_enable", i);
     snprintf(typeId, sizeof(typeId), "cfg_timer_%d_type", i);
     snprintf(timeValueId, sizeof(timeValueId), "cfg_timer_%d_time_value", i);
@@ -361,45 +366,63 @@ void webCallback(const char *elementId, const char *value) {
     snprintf(saturdayId, sizeof(saturdayId), "cfg_timer_%d_saturday", i);
     snprintf(sundayId, sizeof(sundayId), "cfg_timer_%d_sunday", i);
 
+    snprintf(useMinTime, sizeof(useMinTime), "cfg_timer_%d_use_min_time", i);
+    snprintf(useMaxTime, sizeof(useMaxTime), "cfg_timer_%d_use_max_time", i);
+    snprintf(minTimeValueId, sizeof(minTimeValueId), "cfg_timer_%d_min_time_value", i);
+    snprintf(maxTimeValueId, sizeof(maxTimeValueId), "cfg_timer_%d_max_time_value", i);
+
     if (strcmp(elementId, enableId) == 0) {
       config.timer[i].enable = EspStrUtil::stringToBool(value);
     }
-    if (strcmp(elementId, typeId) == 0) {
+    else if (strcmp(elementId, typeId) == 0) {
       config.timer[i].type = atoi(value);
     }
-    if (strcmp(elementId, timeValueId) == 0) {
+    else if (strcmp(elementId, timeValueId) == 0) {
       snprintf(config.timer[i].time_value, sizeof(config.timer[i].time_value), "%s", value);
     }
-    if (strcmp(elementId, offsetValueId) == 0) {
+    else if (strcmp(elementId, offsetValueId) == 0) {
       config.timer[i].offset_value = atoi(value);
     }
-    if (strcmp(elementId, cmdId) == 0) {
+    else if (strcmp(elementId, cmdId) == 0) {
       config.timer[i].cmd = atoi(value);
     }
-    if (strcmp(elementId, maskId) == 0) {
+    else if (strcmp(elementId, maskId) == 0) {
       config.timer[i].grp_mask = strtoul(value, NULL, 2);
     }
 
-    if (strcmp(elementId, mondayId) == 0) {
+    else if (strcmp(elementId, mondayId) == 0) {
       config.timer[i].monday = EspStrUtil::stringToBool(value);
     }
-    if (strcmp(elementId, tuesdayId) == 0) {
+    else if (strcmp(elementId, tuesdayId) == 0) {
       config.timer[i].tuesday = EspStrUtil::stringToBool(value);
     }
-    if (strcmp(elementId, wednesdayId) == 0) {
+    else if (strcmp(elementId, wednesdayId) == 0) {
       config.timer[i].wednesday = EspStrUtil::stringToBool(value);
     }
-    if (strcmp(elementId, thursdayId) == 0) {
+    else if (strcmp(elementId, thursdayId) == 0) {
       config.timer[i].thursday = EspStrUtil::stringToBool(value);
     }
-    if (strcmp(elementId, fridayId) == 0) {
+    else if (strcmp(elementId, fridayId) == 0) {
       config.timer[i].friday = EspStrUtil::stringToBool(value);
     }
-    if (strcmp(elementId, saturdayId) == 0) {
+    else if (strcmp(elementId, saturdayId) == 0) {
       config.timer[i].saturday = EspStrUtil::stringToBool(value);
     }
-    if (strcmp(elementId, sundayId) == 0) {
+    else if (strcmp(elementId, sundayId) == 0) {
       config.timer[i].sunday = EspStrUtil::stringToBool(value);
+    }
+
+    else if (strcmp(elementId, useMinTime) == 0) {
+      config.timer[i].use_min_time = EspStrUtil::stringToBool(value);
+    }
+    else if (strcmp(elementId, useMaxTime) == 0) {
+      config.timer[i].use_max_time = EspStrUtil::stringToBool(value);
+    }
+    else if (strcmp(elementId, minTimeValueId) == 0) {
+      snprintf(config.timer[i].min_time_value, sizeof(config.timer[i].min_time_value), "%s", value);
+    }
+    else if (strcmp(elementId, maxTimeValueId) == 0) {
+      snprintf(config.timer[i].max_time_value, sizeof(config.timer[i].max_time_value), "%s", value);
     }
   }
 

--- a/web/css/custom.css
+++ b/web/css/custom.css
@@ -9,3 +9,7 @@
 .settings-container > div {
   flex: 1;
 }
+
+.minmaxtime-switch {
+  margin-bottom: 10px;
+}

--- a/web/html/03_timer.html
+++ b/web/html/03_timer.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" type="text/css" href="../css/icons.css" />
     <script src="../js/fun.js" defer></script>
     <script src="../js/doc.js" defer></script>
+    <script src="../js/user.js" defer></script>
     <script src="../js/lang.js" defer></script>
     <style></style>
     <script>
@@ -55,7 +56,7 @@
                     id="cfg_timer_0_type"
                     name="timeType0"
                     data-toggle="timeInputs"
-                    onchange="toggleTimeInputs(this)">
+                    onchange="userToggleTimeInputs(this)">
                     <option value="0" data-i18n="time"></option>
                     <option value="1" data-i18n="sunrise"></option>
                     <option value="2" data-i18n="sundown"></option>
@@ -80,6 +81,45 @@
                       name="offsetValue0"
                       placeholder="0"
                       step="1" />
+                  </div>
+
+                  <!-- min/max time settings for sunrise/sundown -->
+                  <div id="timer0-minmaxtime-settings" style="display: none">
+                    <div class="minmaxtime-switch">
+                      <input
+                        name="timer0_use_min_time"
+                        type="checkbox"
+                        role="switch"
+                        hideOpt="OPT_MINTIME0"
+                        id="cfg_timer_0_use_min_time" />
+
+                      <label for="timer0_use_min_time" data-i18n="use_min_time"></label>
+                    </div>
+
+                    <div class="time-input OPT_MINTIME0" id="minTimeInput0">
+                      <input
+                        type="time"
+                        id="cfg_timer_0_min_time_value"
+                        name="minTimeValue0" />
+                    </div>
+
+                    <div class="minmaxtime-switch">
+                      <input
+                        name="timer0_use_max_time"
+                        type="checkbox"
+                        role="switch"
+                        hideOpt="OPT_MAXTIME0"
+                        id="cfg_timer_0_use_max_time" />
+                        
+                      <label for="timer0_use_max_time" data-i18n="use_max_time"></label>
+                    </div>
+                    
+                    <div class="time-input OPT_MAXTIME0" id="maxTimeInput0">
+                      <input
+                        type="time"
+                        id="cfg_timer_0_max_time_value"
+                        name="maxTimeValue0" />
+                    </div>
                   </div>
 
                   <!-- Dropdown for shutter cmd -->
@@ -196,7 +236,7 @@
                     id="cfg_timer_1_type"
                     name="timeType1"
                     data-toggle="timeInputs"
-                    onchange="toggleTimeInputs(this)">
+                    onchange="userToggleTimeInputs(this)">
                     <option value="0" data-i18n="time"></option>
                     <option value="1" data-i18n="sunrise"></option>
                     <option value="2" data-i18n="sundown"></option>
@@ -221,6 +261,45 @@
                       name="offsetValue1"
                       placeholder="0"
                       step="1" />
+                  </div>
+
+                  <!-- min/max time settings for sunrise/sundown -->
+                  <div id="timer1-minmaxtime-settings" style="display: none">
+                    <div class="minmaxtime-switch">
+                      <input
+                        name="timer1_use_min_time"
+                        type="checkbox"
+                        role="switch"
+                        hideOpt="OPT_MINTIME1"
+                        id="cfg_timer_1_use_min_time" />
+
+                      <label for="timer1_use_min_time" data-i18n="use_min_time"></label>
+                    </div>
+
+                    <div class="time-input OPT_MINTIME1" id="minTimeInput1">
+                      <input
+                        type="time"
+                        id="cfg_timer_1_min_time_value"
+                        name="minTimeValue1" />
+                    </div>
+
+                    <div class="minmaxtime-switch">
+                      <input
+                        name="timer1_use_max_time"
+                        type="checkbox"
+                        role="switch"
+                        hideOpt="OPT_MAXTIME1"
+                        id="cfg_timer_1_use_max_time" />
+                        
+                      <label for="timer1_use_max_time" data-i18n="use_max_time"></label>
+                    </div>
+                    
+                    <div class="time-input OPT_MAXTIME1" id="maxTimeInput1">
+                      <input
+                        type="time"
+                        id="cfg_timer_1_max_time_value"
+                        name="maxTimeValue1" />
+                    </div>
                   </div>
 
                   <!-- Dropdown for shutter cmd -->
@@ -337,7 +416,7 @@
                     id="cfg_timer_2_type"
                     name="timeType2"
                     data-toggle="timeInputs"
-                    onchange="toggleTimeInputs(this)">
+                    onchange="userToggleTimeInputs(this)">
                     <option value="0" data-i18n="time"></option>
                     <option value="1" data-i18n="sunrise"></option>
                     <option value="2" data-i18n="sundown"></option>
@@ -349,6 +428,45 @@
                       type="time"
                       id="cfg_timer_2_time_value"
                       name="timeValue2" />
+                  </div>
+
+                  <!-- min/max time settings for sunrise/sundown -->
+                  <div id="timer2-minmaxtime-settings" style="display: none">
+                    <div class="minmaxtime-switch">
+                      <input
+                        name="timer2_use_min_time"
+                        type="checkbox"
+                        role="switch"
+                        hideOpt="OPT_MINTIME2"
+                        id="cfg_timer_2_use_min_time" />
+
+                      <label for="timer2_use_min_time" data-i18n="use_min_time"></label>
+                    </div>
+
+                    <div class="time-input OPT_MINTIME2" id="minTimeInput2">
+                      <input
+                        type="time"
+                        id="cfg_timer_2_min_time_value"
+                        name="minTimeValue2" />
+                    </div>
+
+                    <div class="minmaxtime-switch">
+                      <input
+                        name="timer2_use_max_time"
+                        type="checkbox"
+                        role="switch"
+                        hideOpt="OPT_MAXTIME2"
+                        id="cfg_timer_2_use_max_time" />
+                        
+                      <label for="timer2_use_max_time" data-i18n="use_max_time"></label>
+                    </div>
+                    
+                    <div class="time-input OPT_MAXTIME2" id="maxTimeInput2">
+                      <input
+                        type="time"
+                        id="cfg_timer_2_max_time_value"
+                        name="maxTimeValue2" />
+                    </div>
                   </div>
 
                   <div
@@ -478,7 +596,7 @@
                     id="cfg_timer_3_type"
                     name="timeType3"
                     data-toggle="timeInputs"
-                    onchange="toggleTimeInputs(this)">
+                    onchange="userToggleTimeInputs(this)">
                     <option value="0" data-i18n="time"></option>
                     <option value="1" data-i18n="sunrise"></option>
                     <option value="2" data-i18n="sundown"></option>
@@ -490,6 +608,45 @@
                       type="time"
                       id="cfg_timer_3_time_value"
                       name="timeValue3" />
+                  </div>
+
+                  <!-- min/max time settings for sunrise/sundown -->
+                  <div id="timer3-minmaxtime-settings" style="display: none">
+                    <div class="minmaxtime-switch">
+                      <input
+                        name="timer3_use_min_time"
+                        type="checkbox"
+                        role="switch"
+                        hideOpt="OPT_MINTIME3"
+                        id="cfg_timer_3_use_min_time" />
+
+                      <label for="timer3_use_min_time" data-i18n="use_min_time"></label>
+                    </div>
+
+                    <div class="time-input OPT_MINTIME3" id="minTimeInput3">
+                      <input
+                        type="time"
+                        id="cfg_timer_3_min_time_value"
+                        name="minTimeValue3" />
+                    </div>
+
+                    <div class="minmaxtime-switch">
+                      <input
+                        name="timer3_use_max_time"
+                        type="checkbox"
+                        role="switch"
+                        hideOpt="OPT_MAXTIME3"
+                        id="cfg_timer_3_use_max_time" />
+                        
+                      <label for="timer3_use_max_time" data-i18n="use_max_time"></label>
+                    </div>
+                    
+                    <div class="time-input OPT_MAXTIME3" id="maxTimeInput3">
+                      <input
+                        type="time"
+                        id="cfg_timer_3_max_time_value"
+                        name="maxTimeValue3" />
+                    </div>
                   </div>
 
                   <div
@@ -619,7 +776,7 @@
                     id="cfg_timer_4_type"
                     name="timeType4"
                     data-toggle="timeInputs"
-                    onchange="toggleTimeInputs(this)">
+                    onchange="userToggleTimeInputs(this)">
                     <option value="0" data-i18n="time"></option>
                     <option value="1" data-i18n="sunrise"></option>
                     <option value="2" data-i18n="sundown"></option>
@@ -631,6 +788,45 @@
                       type="time"
                       id="cfg_timer_4_time_value"
                       name="timeValue4" />
+                  </div>
+
+                  <!-- min/max time settings for sunrise/sundown -->
+                  <div id="timer4-minmaxtime-settings" style="display: none">
+                    <div class="minmaxtime-switch">
+                      <input
+                        name="timer4_use_min_time"
+                        type="checkbox"
+                        role="switch"
+                        hideOpt="OPT_MINTIME4"
+                        id="cfg_timer_4_use_min_time" />
+
+                      <label for="timer4_use_min_time" data-i18n="use_min_time"></label>
+                    </div>
+
+                    <div class="time-input OPT_MINTIME4" id="minTimeInput4">
+                      <input
+                        type="time"
+                        id="cfg_timer_4_min_time_value"
+                        name="minTimeValue4" />
+                    </div>
+
+                    <div class="minmaxtime-switch">
+                      <input
+                        name="timer4_use_max_time"
+                        type="checkbox"
+                        role="switch"
+                        hideOpt="OPT_MAXTIME4"
+                        id="cfg_timer_4_use_max_time" />
+                        
+                      <label for="timer4_use_max_time" data-i18n="use_max_time"></label>
+                    </div>
+                    
+                    <div class="time-input OPT_MAXTIME4" id="maxTimeInput4">
+                      <input
+                        type="time"
+                        id="cfg_timer_4_max_time_value"
+                        name="maxTimeValue4" />
+                    </div>
                   </div>
 
                   <div
@@ -760,7 +956,7 @@
                     id="cfg_timer_5_type"
                     name="timeType5"
                     data-toggle="timeInputs"
-                    onchange="toggleTimeInputs(this)">
+                    onchange="userToggleTimeInputs(this)">
                     <option value="0" data-i18n="time"></option>
                     <option value="1" data-i18n="sunrise"></option>
                     <option value="2" data-i18n="sundown"></option>
@@ -772,6 +968,45 @@
                       type="time"
                       id="cfg_timer_5_time_value"
                       name="timeValue5" />
+                  </div>
+
+                  <!-- min/max time settings for sunrise/sundown -->
+                  <div id="timer5-minmaxtime-settings" style="display: none">
+                    <div class="minmaxtime-switch">
+                      <input
+                        name="timer5_use_min_time"
+                        type="checkbox"
+                        role="switch"
+                        hideOpt="OPT_MINTIME5"
+                        id="cfg_timer_5_use_min_time" />
+
+                      <label for="timer5_use_min_time" data-i18n="use_min_time"></label>
+                    </div>
+
+                    <div class="time-input OPT_MINTIME5" id="minTimeInput5">
+                      <input
+                        type="time"
+                        id="cfg_timer_5_min_time_value"
+                        name="minTimeValue5" />
+                    </div>
+
+                    <div class="minmaxtime-switch">
+                      <input
+                        name="timer5_use_max_time"
+                        type="checkbox"
+                        role="switch"
+                        hideOpt="OPT_MAXTIME5"
+                        id="cfg_timer_5_use_max_time" />
+                        
+                      <label for="timer5_use_max_time" data-i18n="use_max_time"></label>
+                    </div>
+                    
+                    <div class="time-input OPT_MAXTIME5" id="maxTimeInput5">
+                      <input
+                        type="time"
+                        id="cfg_timer_5_max_time_value"
+                        name="maxTimeValue5" />
+                    </div>
                   </div>
 
                   <div

--- a/web/js/lang.js
+++ b/web/js/lang.js
@@ -130,6 +130,14 @@ const user_translations = {
     de: "Zeit (HH:MM)",
     en: "Time (HH:MM)",
   },
+  use_min_time: {
+    de: "Frühestens um (HH:MM)",
+    en: "Not earlier than (HH:MM)",
+  },
+  use_max_time: {
+    de: "Spätestes um (HH:MM)",
+    en: "Not later than (HH:MM)",
+  },
   offset_desc: {
     de: "Offset in Minuten (z. B. -15 oder +20)",
     en: "Offset in Minutens (e.g. -15 oder +20)",

--- a/web/js/user.js
+++ b/web/js/user.js
@@ -106,3 +106,21 @@ async function loadSimulatedData() {
     console.error("Fehler beim Laden von sim.json:", error);
   }
 }
+
+
+function userToggleTimeInputs(selectElement) {
+  toggleTimeInputs(selectElement);
+
+  const matches = selectElement.id.match(/\d+/g);
+  const timerId = matches[matches.length - 1];
+  const minMaxTimeSettings = document.getElementById(`timer${timerId}-minmaxtime-settings`);
+
+  //  value: 0 == fixed Time
+  if (selectElement.value === "0") {
+    minMaxTimeSettings.style.display = "none";
+  }
+  // otherwise sunrise/sundown
+  else {
+    minMaxTimeSettings.style.display = "block";
+  }
+}

--- a/web/output/index.html
+++ b/web/output/index.html
@@ -594,7 +594,7 @@
                     id="cfg_timer_0_type"
                     name="timeType0"
                     data-toggle="timeInputs"
-                    onchange="toggleTimeInputs(this)">
+                    onchange="userToggleTimeInputs(this)">
                     <option value="0" data-i18n="time"></option>
                     <option value="1" data-i18n="sunrise"></option>
                     <option value="2" data-i18n="sundown"></option>
@@ -619,6 +619,45 @@
                       name="offsetValue0"
                       placeholder="0"
                       step="1" />
+                  </div>
+
+                  <!-- min/max time settings for sunrise/sundown -->
+                  <div id="timer0-minmaxtime-settings" style="display: none">
+                    <div class="minmaxtime-switch">
+                      <input
+                        name="timer0_use_min_time"
+                        type="checkbox"
+                        role="switch"
+                        hideOpt="OPT_MINTIME0"
+                        id="cfg_timer_0_use_min_time" />
+
+                      <label for="timer0_use_min_time" data-i18n="use_min_time"></label>
+                    </div>
+
+                    <div class="time-input OPT_MINTIME0" id="minTimeInput0">
+                      <input
+                        type="time"
+                        id="cfg_timer_0_min_time_value"
+                        name="minTimeValue0" />
+                    </div>
+
+                    <div class="minmaxtime-switch">
+                      <input
+                        name="timer0_use_max_time"
+                        type="checkbox"
+                        role="switch"
+                        hideOpt="OPT_MAXTIME0"
+                        id="cfg_timer_0_use_max_time" />
+                        
+                      <label for="timer0_use_max_time" data-i18n="use_max_time"></label>
+                    </div>
+                    
+                    <div class="time-input OPT_MAXTIME0" id="maxTimeInput0">
+                      <input
+                        type="time"
+                        id="cfg_timer_0_max_time_value"
+                        name="maxTimeValue0" />
+                    </div>
                   </div>
 
                   <!-- Dropdown for shutter cmd -->
@@ -735,7 +774,7 @@
                     id="cfg_timer_1_type"
                     name="timeType1"
                     data-toggle="timeInputs"
-                    onchange="toggleTimeInputs(this)">
+                    onchange="userToggleTimeInputs(this)">
                     <option value="0" data-i18n="time"></option>
                     <option value="1" data-i18n="sunrise"></option>
                     <option value="2" data-i18n="sundown"></option>
@@ -760,6 +799,45 @@
                       name="offsetValue1"
                       placeholder="0"
                       step="1" />
+                  </div>
+
+                  <!-- min/max time settings for sunrise/sundown -->
+                  <div id="timer1-minmaxtime-settings" style="display: none">
+                    <div class="minmaxtime-switch">
+                      <input
+                        name="timer1_use_min_time"
+                        type="checkbox"
+                        role="switch"
+                        hideOpt="OPT_MINTIME1"
+                        id="cfg_timer_1_use_min_time" />
+
+                      <label for="timer1_use_min_time" data-i18n="use_min_time"></label>
+                    </div>
+
+                    <div class="time-input OPT_MINTIME1" id="minTimeInput1">
+                      <input
+                        type="time"
+                        id="cfg_timer_1_min_time_value"
+                        name="minTimeValue1" />
+                    </div>
+
+                    <div class="minmaxtime-switch">
+                      <input
+                        name="timer1_use_max_time"
+                        type="checkbox"
+                        role="switch"
+                        hideOpt="OPT_MAXTIME1"
+                        id="cfg_timer_1_use_max_time" />
+                        
+                      <label for="timer1_use_max_time" data-i18n="use_max_time"></label>
+                    </div>
+                    
+                    <div class="time-input OPT_MAXTIME1" id="maxTimeInput1">
+                      <input
+                        type="time"
+                        id="cfg_timer_1_max_time_value"
+                        name="maxTimeValue1" />
+                    </div>
                   </div>
 
                   <!-- Dropdown for shutter cmd -->
@@ -876,7 +954,7 @@
                     id="cfg_timer_2_type"
                     name="timeType2"
                     data-toggle="timeInputs"
-                    onchange="toggleTimeInputs(this)">
+                    onchange="userToggleTimeInputs(this)">
                     <option value="0" data-i18n="time"></option>
                     <option value="1" data-i18n="sunrise"></option>
                     <option value="2" data-i18n="sundown"></option>
@@ -888,6 +966,45 @@
                       type="time"
                       id="cfg_timer_2_time_value"
                       name="timeValue2" />
+                  </div>
+
+                  <!-- min/max time settings for sunrise/sundown -->
+                  <div id="timer2-minmaxtime-settings" style="display: none">
+                    <div class="minmaxtime-switch">
+                      <input
+                        name="timer2_use_min_time"
+                        type="checkbox"
+                        role="switch"
+                        hideOpt="OPT_MINTIME2"
+                        id="cfg_timer_2_use_min_time" />
+
+                      <label for="timer2_use_min_time" data-i18n="use_min_time"></label>
+                    </div>
+
+                    <div class="time-input OPT_MINTIME2" id="minTimeInput2">
+                      <input
+                        type="time"
+                        id="cfg_timer_2_min_time_value"
+                        name="minTimeValue2" />
+                    </div>
+
+                    <div class="minmaxtime-switch">
+                      <input
+                        name="timer2_use_max_time"
+                        type="checkbox"
+                        role="switch"
+                        hideOpt="OPT_MAXTIME2"
+                        id="cfg_timer_2_use_max_time" />
+                        
+                      <label for="timer2_use_max_time" data-i18n="use_max_time"></label>
+                    </div>
+                    
+                    <div class="time-input OPT_MAXTIME2" id="maxTimeInput2">
+                      <input
+                        type="time"
+                        id="cfg_timer_2_max_time_value"
+                        name="maxTimeValue2" />
+                    </div>
                   </div>
 
                   <div
@@ -1017,7 +1134,7 @@
                     id="cfg_timer_3_type"
                     name="timeType3"
                     data-toggle="timeInputs"
-                    onchange="toggleTimeInputs(this)">
+                    onchange="userToggleTimeInputs(this)">
                     <option value="0" data-i18n="time"></option>
                     <option value="1" data-i18n="sunrise"></option>
                     <option value="2" data-i18n="sundown"></option>
@@ -1029,6 +1146,45 @@
                       type="time"
                       id="cfg_timer_3_time_value"
                       name="timeValue3" />
+                  </div>
+
+                  <!-- min/max time settings for sunrise/sundown -->
+                  <div id="timer3-minmaxtime-settings" style="display: none">
+                    <div class="minmaxtime-switch">
+                      <input
+                        name="timer3_use_min_time"
+                        type="checkbox"
+                        role="switch"
+                        hideOpt="OPT_MINTIME3"
+                        id="cfg_timer_3_use_min_time" />
+
+                      <label for="timer3_use_min_time" data-i18n="use_min_time"></label>
+                    </div>
+
+                    <div class="time-input OPT_MINTIME3" id="minTimeInput3">
+                      <input
+                        type="time"
+                        id="cfg_timer_3_min_time_value"
+                        name="minTimeValue3" />
+                    </div>
+
+                    <div class="minmaxtime-switch">
+                      <input
+                        name="timer3_use_max_time"
+                        type="checkbox"
+                        role="switch"
+                        hideOpt="OPT_MAXTIME3"
+                        id="cfg_timer_3_use_max_time" />
+                        
+                      <label for="timer3_use_max_time" data-i18n="use_max_time"></label>
+                    </div>
+                    
+                    <div class="time-input OPT_MAXTIME3" id="maxTimeInput3">
+                      <input
+                        type="time"
+                        id="cfg_timer_3_max_time_value"
+                        name="maxTimeValue3" />
+                    </div>
                   </div>
 
                   <div
@@ -1158,7 +1314,7 @@
                     id="cfg_timer_4_type"
                     name="timeType4"
                     data-toggle="timeInputs"
-                    onchange="toggleTimeInputs(this)">
+                    onchange="userToggleTimeInputs(this)">
                     <option value="0" data-i18n="time"></option>
                     <option value="1" data-i18n="sunrise"></option>
                     <option value="2" data-i18n="sundown"></option>
@@ -1170,6 +1326,45 @@
                       type="time"
                       id="cfg_timer_4_time_value"
                       name="timeValue4" />
+                  </div>
+
+                  <!-- min/max time settings for sunrise/sundown -->
+                  <div id="timer4-minmaxtime-settings" style="display: none">
+                    <div class="minmaxtime-switch">
+                      <input
+                        name="timer4_use_min_time"
+                        type="checkbox"
+                        role="switch"
+                        hideOpt="OPT_MINTIME4"
+                        id="cfg_timer_4_use_min_time" />
+
+                      <label for="timer4_use_min_time" data-i18n="use_min_time"></label>
+                    </div>
+
+                    <div class="time-input OPT_MINTIME4" id="minTimeInput4">
+                      <input
+                        type="time"
+                        id="cfg_timer_4_min_time_value"
+                        name="minTimeValue4" />
+                    </div>
+
+                    <div class="minmaxtime-switch">
+                      <input
+                        name="timer4_use_max_time"
+                        type="checkbox"
+                        role="switch"
+                        hideOpt="OPT_MAXTIME4"
+                        id="cfg_timer_4_use_max_time" />
+                        
+                      <label for="timer4_use_max_time" data-i18n="use_max_time"></label>
+                    </div>
+                    
+                    <div class="time-input OPT_MAXTIME4" id="maxTimeInput4">
+                      <input
+                        type="time"
+                        id="cfg_timer_4_max_time_value"
+                        name="maxTimeValue4" />
+                    </div>
                   </div>
 
                   <div
@@ -1299,7 +1494,7 @@
                     id="cfg_timer_5_type"
                     name="timeType5"
                     data-toggle="timeInputs"
-                    onchange="toggleTimeInputs(this)">
+                    onchange="userToggleTimeInputs(this)">
                     <option value="0" data-i18n="time"></option>
                     <option value="1" data-i18n="sunrise"></option>
                     <option value="2" data-i18n="sundown"></option>
@@ -1311,6 +1506,45 @@
                       type="time"
                       id="cfg_timer_5_time_value"
                       name="timeValue5" />
+                  </div>
+
+                  <!-- min/max time settings for sunrise/sundown -->
+                  <div id="timer5-minmaxtime-settings" style="display: none">
+                    <div class="minmaxtime-switch">
+                      <input
+                        name="timer5_use_min_time"
+                        type="checkbox"
+                        role="switch"
+                        hideOpt="OPT_MINTIME5"
+                        id="cfg_timer_5_use_min_time" />
+
+                      <label for="timer5_use_min_time" data-i18n="use_min_time"></label>
+                    </div>
+
+                    <div class="time-input OPT_MINTIME5" id="minTimeInput5">
+                      <input
+                        type="time"
+                        id="cfg_timer_5_min_time_value"
+                        name="minTimeValue5" />
+                    </div>
+
+                    <div class="minmaxtime-switch">
+                      <input
+                        name="timer5_use_max_time"
+                        type="checkbox"
+                        role="switch"
+                        hideOpt="OPT_MAXTIME5"
+                        id="cfg_timer_5_use_max_time" />
+                        
+                      <label for="timer5_use_max_time" data-i18n="use_max_time"></label>
+                    </div>
+                    
+                    <div class="time-input OPT_MAXTIME5" id="maxTimeInput5">
+                      <input
+                        type="time"
+                        id="cfg_timer_5_max_time_value"
+                        name="maxTimeValue5" />
+                    </div>
                   </div>
 
                   <div

--- a/web/output/user.css
+++ b/web/output/user.css
@@ -9,6 +9,10 @@
 .settings-container > div {
   flex: 1;
 }
+
+.minmaxtime-switch {
+  margin-bottom: 10px;
+}
 .i_shade {
   background-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" fill="%23fff" style="enable-background:new 0 0 122.88 118.77" viewBox="0 -2.05 122.88 122.88"><path d="M1.22.04h115.79c.14-.02.28-.04.43-.04.15 0 .29.01.43.04.21.01.4.06.57.16.91.38 1.54 1.25 1.54 2.27v99.12c0 .09-.01.19-.02.28 1.73.91 2.92 2.73 2.92 4.82v6.65c0 2.99-2.45 5.44-5.44 5.44s-5.44-2.45-5.44-5.44v-6.65c0-2.08 1.19-3.9 2.92-4.82-.01-.09-.02-.18-.02-.28v-91.3H1.22C.55 10.29 0 9.75 0 9.08V1.25C0 .58.55.04 1.22.04zm1.99 92.17h103.98v4.91H3.21v-4.91zm0-12.5h103.98v4.91H3.21v-4.91zm0-12.5h103.98v4.91H3.21v-4.91zm0-12.5h103.98v4.91H3.21v-4.91zm0-12.51h103.98v4.91H3.21V42.2zm0-12.5h103.98v4.91H3.21V29.7zm0-12.5h103.98v4.91H3.21V17.2z" style="fill-rule:evenodd;clip-rule:evenodd"/></svg>');
 }

--- a/web/output/user.js
+++ b/web/output/user.js
@@ -130,6 +130,14 @@ const user_translations = {
     de: "Zeit (HH:MM)",
     en: "Time (HH:MM)",
   },
+  use_min_time: {
+    de: "Frühestens um (HH:MM)",
+    en: "Not earlier than (HH:MM)",
+  },
+  use_max_time: {
+    de: "Spätestes um (HH:MM)",
+    en: "Not later than (HH:MM)",
+  },
   offset_desc: {
     de: "Offset in Minuten (z. B. -15 oder +20)",
     en: "Offset in Minutens (e.g. -15 oder +20)",
@@ -321,3 +329,20 @@ async function loadSimulatedData() {
   }
 }
 
+
+function userToggleTimeInputs(selectElement) {
+  toggleTimeInputs(selectElement);
+
+  const matches = selectElement.id.match(/\d+/g);
+  const timerId = matches[matches.length - 1];
+  const minMaxTimeSettings = document.getElementById(`timer${timerId}-minmaxtime-settings`);
+
+  //  value: 0 == fixed Time
+  if (selectElement.value === "0") {
+    minMaxTimeSettings.style.display = "none";
+  }
+  // otherwise sunrise/sundown
+  else {
+    minMaxTimeSettings.style.display = "block";
+  }
+}


### PR DESCRIPTION
Das ist ein Feature, das ich von ASC von fhem kenne und sehr nützlich ist.
Z.B. geht die Sonne im Sommer schon um 5:00 auf. Da möchte ich nicht, dass die Rolläden schon hochgehen.
Deshalb kann man damit dann eine frühestmögliche Zeit festlegen, z.B. 6:30.

In der UI sieht es so aus:
![image](https://github.com/user-attachments/assets/c248924e-6385-4926-95df-6ee9bf291ff1)

Hinweis:
ich musste wegen den Änderungen in der 1.7.0 Version eine neue JS-Funktion userToggleTimeInputs() einbauen, weil die toggleTimeInputs jetzt ausgelagert ist.